### PR TITLE
Prepare for release 8.0.3-v11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	kmodules.xyz/client-go v0.0.0-20210617233340-13d22e91512b
 	kmodules.xyz/custom-resources v0.0.0-20210618003440-c6bb400da153
 	kmodules.xyz/offshoot-api v0.0.0-20210618005544-5217a24765da
-	stash.appscode.dev/apimachinery v0.14.1-0.20210618025054-0cae462d7e04
+	stash.appscode.dev/apimachinery v0.14.1
 )
 
 replace bitbucket.org/ww/goautoneg => gomodules.xyz/goautoneg v0.0.0-20120707110453-a547fc61f48d

--- a/go.sum
+++ b/go.sum
@@ -1054,5 +1054,5 @@ sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
-stash.appscode.dev/apimachinery v0.14.1-0.20210618025054-0cae462d7e04 h1:7cnkwSU9ACHkN+qHv15EKdftXGqHyK8G5fJ+aVUSvk4=
-stash.appscode.dev/apimachinery v0.14.1-0.20210618025054-0cae462d7e04/go.mod h1:/Ys7EVp/ved+2xkfhqMbRpaJtI3p/KpCPRLJ6ZgDddA=
+stash.appscode.dev/apimachinery v0.14.1 h1:HU6ediYchu138WckGEN+uXF7l99kd9bAbqBeZFnQLNk=
+stash.appscode.dev/apimachinery v0.14.1/go.mod h1:/Ys7EVp/ved+2xkfhqMbRpaJtI3p/KpCPRLJ6ZgDddA=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -575,7 +575,7 @@ sigs.k8s.io/structured-merge-diff/v4/typed
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
-# stash.appscode.dev/apimachinery v0.14.1-0.20210618025054-0cae462d7e04
+# stash.appscode.dev/apimachinery v0.14.1
 ## explicit
 stash.appscode.dev/apimachinery/apis
 stash.appscode.dev/apimachinery/apis/repositories


### PR DESCRIPTION
ProductLine: Stash
Release: v2021.06.23
Release-tracker: https://github.com/stashed/CHANGELOG/pull/38
Signed-off-by: 1gtm <1gtm@appscode.com>