### PR TITLE
Prepare for release 5.7.25-v33

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	kmodules.xyz/client-go v0.30.42
 	kmodules.xyz/custom-resources v0.30.0
 	kmodules.xyz/offshoot-api v0.30.1
-	stash.appscode.dev/apimachinery v0.36.1-0.20241217113844-8f07b3c52464
+	stash.appscode.dev/apimachinery v0.37.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -554,5 +554,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+s
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=
-stash.appscode.dev/apimachinery v0.36.1-0.20241217113844-8f07b3c52464 h1:dq8NIka54jlwqV8JGYp3S4n5i/bxF3KkJXj2nuo3Vo0=
-stash.appscode.dev/apimachinery v0.36.1-0.20241217113844-8f07b3c52464/go.mod h1:Q+GTcB8/VWNqG9yywbMBWiRDnYT29tnEDnGnCYtKq4g=
+stash.appscode.dev/apimachinery v0.37.0 h1:dwKOX6XHTbTMxxRB4+nEyy740NT6+n/Rmr6Cfp+vRqE=
+stash.appscode.dev/apimachinery v0.37.0/go.mod h1:Q+GTcB8/VWNqG9yywbMBWiRDnYT29tnEDnGnCYtKq4g=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -822,7 +822,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
-# stash.appscode.dev/apimachinery v0.36.1-0.20241217113844-8f07b3c52464
+# stash.appscode.dev/apimachinery v0.37.0
 ## explicit; go 1.22.0
 stash.appscode.dev/apimachinery/apis
 stash.appscode.dev/apimachinery/apis/repositories


### PR DESCRIPTION
ProductLine: Stash
Release: v2024.12.18
Release-tracker: https://github.com/stashed/CHANGELOG/pull/77
Signed-off-by: 1gtm <1gtm@appscode.com>